### PR TITLE
Make this runnable on its own and allow shallow folders

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ tox = "*"
 matplotlib = "~=3.0.2"
 area = "~=1.1.1"
 numpy = "~=1.15.4"
+mqm = {editable = true,path = "."}
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -84,6 +84,10 @@
             "index": "pypi",
             "version": "==3.0.2"
         },
+        "mqm": {
+            "editable": true,
+            "path": "."
+        },
         "numpy": {
             "hashes": [
                 "sha256:0df89ca13c25eaa1621a3f09af4c8ba20da849692dcae184cb55e80952c453fb",

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ OpenStreetMap (OSM) data quality is always a concern and frequently a barrier fo
 
 # Usage
 
+Eventually, this project will be on PyPI, which will make the following steps only necessary for development.
+
 **Installing dependencies**
 
-To utilize the MQM tool, please install Python3 and `pipenv`. Then, run the following command to install all of the dependencies: <br />
+To run the MQM tool from source, please install Python3 and `pipenv`. Then, run the following command to install all of the dependencies: <br />
 ```
 pipenv install
 ```
@@ -22,12 +24,12 @@ pipenv shell
 2. run the program through applying <br />
 
 ```
-python3 -m src.mqm --folderPath [a absolute folder path] --maxDepth [maximum tree depth (default = 10)]
+python3 -m mqm --folderPath [a absolute folder path] --maxDepth [maximum tree depth (default = 10)]
 --countNum [a count number (default = 10)] --gridPercent [a grid percentage (default = 0.9)]
 --maxCount [maximum count to the second k-d tree]
 
 For example:
-python3 mqm_tool.py --folderPath ~/desktop/program/test_data 
+python3 -m mqm --folderPath ~/desktop/program/test_data
 ```
 
 Note:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pipenv shell
 2. run the program through applying <br />
 
 ```
-python3 mqm_tool.py --folderPath [a absolute folder path] --maxDepth [maximum tree depth (default = 10)]
+python3 -m src.mqm --folderPath [a absolute folder path] --maxDepth [maximum tree depth (default = 10)]
 --countNum [a count number (default = 10)] --gridPercent [a grid percentage (default = 0.9)]
 --maxCount [maximum count to the second k-d tree]
 

--- a/src/mqm/__main__.py
+++ b/src/mqm/__main__.py
@@ -1,0 +1,4 @@
+from .mqm_tool import main
+
+if __name__ == '__main__':
+    main()

--- a/src/mqm/mqm_tool.py
+++ b/src/mqm/mqm_tool.py
@@ -371,7 +371,8 @@ def main():
     # get a sub-directory list
     util = Utility()
     folder_list = util.get_sub_directionaries(input_folder)
-    del util
+    if len(folder_list) == 0:
+        folder_list.append(input_folder)
 
     
     # iterate through all sub-directories


### PR DESCRIPTION
Currently, this does not run (#12). 

This PR adds a `__main__.py` file after working with @Bentleysb and @danielduhh to figure out the best approach. Now, this can be run like so from the root of the project:
`python3 -m src.mqm --folderPath=/Absolute/folder/path`. 

In addition, I added a hotfix that @danielduhh created to allow this to run on a single shallow folder instead of a nested folder. As we improve the way this code is structured, this may change, but it gets the functionality we want for now.

One word of warning: there is currently an issue regarding the location of the created results folder. ~I'll make an issue and add a link here shortly.~ See #14 