### PR TITLE
Match Output Bounding Box to Geojson Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pipenv shell
 ```
 python3 -m mqm --folderPath [a absolute folder path] --maxDepth [maximum tree depth (default = 10)]
 --countNum [a count number (default = 10)] --gridPercent [a grid percentage (default = 0.9)]
---maxCount [maximum count to the second k-d tree]
+--maxCount [maximum count to the second k-d tree] --boundary [a geojson feature, output bbox will match feature's]
 
 For example:
 python3 -m mqm --folderPath ~/desktop/program/test_data

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pipenv shell
 ```
 python3 -m mqm --folderPath [a absolute folder path] --maxDepth [maximum tree depth (default = 10)]
 --countNum [a count number (default = 10)] --gridPercent [a grid percentage (default = 0.9)]
---maxCount [maximum count to the second k-d tree] --boundary [a geojson feature, output bbox will match feature's]
+--maxCount [maximum count to the second k-d tree]
 
 For example:
 python3 -m mqm --folderPath ~/desktop/program/test_data
@@ -36,6 +36,8 @@ Note:
 
 1. Users can adjust all parameters, and minimum value of the depth number is 1.<br />
 2. When users specify the maximum count to the second k-d tree, the tool performs the second tree automatically. <br />
+3. If you add a geojson file name 'boundary.json' to any of the sub-directories of the input folder, the bounding box 
+of the first feature in that file will be used as the bounding box of the folders results.
 
 **Output Format:**
 

--- a/src/mqm/geo_process.py
+++ b/src/mqm/geo_process.py
@@ -18,7 +18,7 @@ class GeoProcessor:
     
     """
     
-    def __init__(self, input_folder_path):
+    def __init__(self, input_folder_path, boundary):
         """ The docstring of the __init__ method.
 
         Args:
@@ -26,6 +26,7 @@ class GeoProcessor:
             
         """
         self.folder_path = input_folder_path
+        self.boundary_file = boundary
 
         #: list of list: a nested list with some important information.
         self.output_data = []
@@ -260,8 +261,17 @@ class GeoProcessor:
                 start_point = len(data['features'])
 
         
-        # get a folder bounding box giving one or more fix bounding box
-        final_bounding_box = self.final_bounding_box_generation(folder_bounding_box_set, 4)
+        # get a folder bounding box giving one or more fix bounding box, or a boundary file
+        if self.boundary_file != '':
+            try:
+                with open(self.boundary_file) as bounds_file:
+                    feature = json.loads(bounds_file.read())["features"][0]["geometry"]
+                final_bounding_box = self.min_max_calculation(feature["type"], feature["coordinates"])
+            except Exception:
+                print("Error reading the boundary file.")
+                raise
+        else:
+            final_bounding_box = self.final_bounding_box_generation(folder_bounding_box_set, 4)
 
         
         return self.output_data, final_bounding_box, name_num_list

--- a/src/mqm/geo_process.py
+++ b/src/mqm/geo_process.py
@@ -18,7 +18,7 @@ class GeoProcessor:
     
     """
     
-    def __init__(self, input_folder_path, boundary):
+    def __init__(self, input_folder_path):
         """ The docstring of the __init__ method.
 
         Args:
@@ -26,7 +26,6 @@ class GeoProcessor:
             
         """
         self.folder_path = input_folder_path
-        self.boundary_file = boundary
 
         #: list of list: a nested list with some important information.
         self.output_data = []
@@ -262,9 +261,9 @@ class GeoProcessor:
 
         
         # get a folder bounding box giving one or more fix bounding box, or a boundary file
-        if self.boundary_file != '':
+        if "boundary.json" in os.listdir(self.folder_path):
             try:
-                with open(self.boundary_file) as bounds_file:
+                with open(os.path.join(self.folder_path, "boundary.json")) as bounds_file:
                     feature = json.loads(bounds_file.read())["features"][0]["geometry"]
                 final_bounding_box = self.min_max_calculation(feature["type"], feature["coordinates"])
             except Exception:

--- a/src/mqm/mqm_tool.py
+++ b/src/mqm/mqm_tool.py
@@ -112,6 +112,7 @@ def get_argument():
     parser.add_argument('--countNum', type=str, default='10', help='a count value for a stop condition')
     parser.add_argument('--gridPercent', type=str, default='0.9', help='a grid percentage')
     parser.add_argument('--maxCount', type=str, default='', help='maximum count to the second k-d tree')
+    parser.add_argument('--boundary', type=str, default='', help='geojson polygon to use for the output extent')
     args = parser.parse_args()
     max_count = -1
     path = 'histogram'
@@ -122,7 +123,7 @@ def get_argument():
     if args.maxCount:
         max_count = int(args.maxCount)
 
-    return folder_path, args.maxDepth, output_folder, int(args.countNum), float(args.gridPercent), max_count, path, geojson_path
+    return folder_path, args.maxDepth, output_folder, int(args.countNum), float(args.gridPercent), max_count, path, geojson_path, args.boundary
 
 
 def stop_condition(count_zero_list, count_list, grid_percent, count_num, cell_num, out_distribution):
@@ -245,7 +246,7 @@ def directory_creation(result_folder_path, sub_folder, path, geojson_path):
         os.makedirs(os.path.join(sub_folder, geojson_path))
         
 
-def process_single_folder(input_folder, folder_path, maximum_level, count_num, grid_percent, max_count, path, geojson_path, flag_val, summary_table, folder_name):
+def process_single_folder(input_folder, folder_path, maximum_level, count_num, grid_percent, max_count, path, geojson_path, flag_val, summary_table, folder_name, boundary):
     """ Single folder process.
 
     This function processes a single folder and runs a k-d tree algorithm.
@@ -265,7 +266,7 @@ def process_single_folder(input_folder, folder_path, maximum_level, count_num, g
         
     """
     # read and parse all geoJson files
-    geo_processor = GeoProcessor(input_folder)
+    geo_processor = GeoProcessor(input_folder, boundary)
     entire_data, out_BB, name_num = geo_processor.bounding_box_process()
     road_file = geo_processor.get_road_file()
     initial_area = geo_processor.get_initial_extend_area(out_BB)
@@ -353,7 +354,7 @@ def main():
     
     """
     # get all arguments
-    input_folder, maximum_level, folder_path, count_num, grid_percent, max_count, path, geojson_path = get_argument()
+    input_folder, maximum_level, folder_path, count_num, grid_percent, max_count, path, geojson_path, boundary = get_argument()
     flag_val = False
     summary_table = [['name','flags','flagged_OSM_feature','totalArea','gridSize']]
     
@@ -370,7 +371,7 @@ def main():
         # process single sub-folder
         process_single_folder(sub_folder, os.path.join(folder_path, os.path.split(sub_folder)[1]), maximum_level,
                               count_num, grid_percent, max_count, path, geojson_path, flag_val, summary_table,
-                              os.path.split(sub_folder)[1])
+                              os.path.split(sub_folder)[1], boundary)
 
     # write out a summary table
     util = Utility()

--- a/src/mqm/mqm_tool.py
+++ b/src/mqm/mqm_tool.py
@@ -112,7 +112,6 @@ def get_argument():
     parser.add_argument('--countNum', type=str, default='10', help='a count value for a stop condition')
     parser.add_argument('--gridPercent', type=str, default='0.9', help='a grid percentage')
     parser.add_argument('--maxCount', type=str, default='', help='maximum count to the second k-d tree')
-    parser.add_argument('--boundary', type=str, default='', help='geojson polygon to use for the output extent')
     args = parser.parse_args()
     max_count = -1
     path = 'histogram'
@@ -123,7 +122,7 @@ def get_argument():
     if args.maxCount:
         max_count = int(args.maxCount)
 
-    return folder_path, args.maxDepth, output_folder, int(args.countNum), float(args.gridPercent), max_count, path, geojson_path, args.boundary
+    return folder_path, args.maxDepth, output_folder, int(args.countNum), float(args.gridPercent), max_count, path, geojson_path
 
 
 def stop_condition(count_zero_list, count_list, grid_percent, count_num, cell_num, out_distribution):
@@ -246,7 +245,7 @@ def directory_creation(result_folder_path, sub_folder, path, geojson_path):
         os.makedirs(os.path.join(sub_folder, geojson_path))
         
 
-def process_single_folder(input_folder, folder_path, maximum_level, count_num, grid_percent, max_count, path, geojson_path, flag_val, summary_table, folder_name, boundary):
+def process_single_folder(input_folder, folder_path, maximum_level, count_num, grid_percent, max_count, path, geojson_path, flag_val, summary_table, folder_name):
     """ Single folder process.
 
     This function processes a single folder and runs a k-d tree algorithm.
@@ -266,7 +265,7 @@ def process_single_folder(input_folder, folder_path, maximum_level, count_num, g
         
     """
     # read and parse all geoJson files
-    geo_processor = GeoProcessor(input_folder, boundary)
+    geo_processor = GeoProcessor(input_folder)
     entire_data, out_BB, name_num = geo_processor.bounding_box_process()
     road_file = geo_processor.get_road_file()
     initial_area = geo_processor.get_initial_extend_area(out_BB)
@@ -354,7 +353,7 @@ def main():
     
     """
     # get all arguments
-    input_folder, maximum_level, folder_path, count_num, grid_percent, max_count, path, geojson_path, boundary = get_argument()
+    input_folder, maximum_level, folder_path, count_num, grid_percent, max_count, path, geojson_path = get_argument()
     flag_val = False
     summary_table = [['name','flags','flagged_OSM_feature','totalArea','gridSize']]
     
@@ -371,7 +370,7 @@ def main():
         # process single sub-folder
         process_single_folder(sub_folder, os.path.join(folder_path, os.path.split(sub_folder)[1]), maximum_level,
                               count_num, grid_percent, max_count, path, geojson_path, flag_val, summary_table,
-                              os.path.split(sub_folder)[1], boundary)
+                              os.path.split(sub_folder)[1])
 
     # write out a summary table
     util = Utility()


### PR DESCRIPTION
This adds the ability to set the initial extent of the k-d tree by passing a geojson file. The initial extent of the k-d tree will be the same as the bounding box of the first feature in the geojson file. This means the mqm results will have the same bounding box as the geojson feature. 
To add a boundary file add it as 'boundary.json' in the sub-directory that it should be applied to. 

![Screen Shot 2019-08-06 at 11 39 44 AM](https://user-images.githubusercontent.com/24948563/62566917-e9b5ce00-b83e-11e9-83e4-db9d3e003b8a.png)
The purple is the mqm results without a boundary file.
The pink is the mqm results with the boundary file.
The yellow is the boundary file. 
