### PR TITLE
Update grid stop condition to be accurate

### DIFF
--- a/src/mqm/mqm_tool.py
+++ b/src/mqm/mqm_tool.py
@@ -125,7 +125,7 @@ def get_argument():
     return folder_path, args.maxDepth, output_folder, int(args.countNum), float(args.gridPercent), max_count, path, geojson_path
 
 
-def stop_condition(count_zero_list, count_list, grid_percent, count_num, cell_num, out_distribution):
+def stop_condition(count_zero_list, count_list, grid_percent, count_num, in_grid_ids, out_distribution):
     """ Stop condition function.
 
     This function calculates the stop condition to the first k-d tree.
@@ -148,7 +148,7 @@ def stop_condition(count_zero_list, count_list, grid_percent, count_num, cell_nu
         
     """
     # variables
-    smallest_max_count = 0
+    smallest_max_count = 0.0
     smallest_max_count_ind = -1
     stop_flag = False
 
@@ -163,29 +163,20 @@ def stop_condition(count_zero_list, count_list, grid_percent, count_num, cell_nu
             smallest_max_count = ele
             smallest_max_count_ind = ind
 
-    # check the stop condition
-    if smallest_max_count_ind != -1:
-        total_count_within_count_num = 0
-        total_grids = 0
-        list_length = 0
+        # check the stop condition
+        if smallest_max_count_ind != -1:
+            total_area = sum(val for _, val in out_distribution.items()) + count_zero_list[1]
+            area_less_threshold = 0
 
-        if not count_zero_list:  # the list is empty
-            list_length = smallest_max_count_ind + 1
-            total_grids = cell_num
-            
-        else:
-            list_length = smallest_max_count_ind + 2
-            total_grids = cell_num + count_zero_list[1]
-
-        for i in range(list_length):
-            if count_list[i] == 0:
-                total_count_within_count_num += count_zero_list[1]
-                
+            if count_list[0] == 0:
+                area_less_threshold = sum(out_distribution[key] for key in count_list[1: smallest_max_count_ind + 1]) + \
+                                      count_zero_list[1]
             else:
-                total_count_within_count_num += out_distribution[count_list[i]]
-        
-        if (float(total_count_within_count_num / total_grids)) > grid_percent:
-            stop_flag = True
+                area_less_threshold = sum(out_distribution[key] for key in count_list[: smallest_max_count_ind + 1])
+
+            # print(area_less_threshold)
+            if (float(area_less_threshold / total_area)) >= grid_percent:
+                stop_flag = True
 
     return stop_flag
 

--- a/src/mqm/mqm_tool.py
+++ b/src/mqm/mqm_tool.py
@@ -125,7 +125,7 @@ def get_argument():
     return folder_path, args.maxDepth, output_folder, int(args.countNum), float(args.gridPercent), max_count, path, geojson_path
 
 
-def stop_condition(count_zero_list, count_list, grid_percent, count_num, in_grid_ids, out_distribution):
+def stop_condition(count_zero_list, count_list, grid_percent, count_num, cell_num, out_distribution):
     """ Stop condition function.
 
     This function calculates the stop condition to the first k-d tree.
@@ -154,7 +154,7 @@ def stop_condition(count_zero_list, count_list, grid_percent, count_num, in_grid
 
     # add zero-count back to the count list and find a maximum count that is smaller than a threshold
     if count_zero_list:
-        count_list.insert(0, count_zero_list[0])
+        count_list.insert(0, float(count_zero_list[0]))
     for ind, ele in enumerate(count_list):
         if ele > count_num:
             break
@@ -169,12 +169,11 @@ def stop_condition(count_zero_list, count_list, grid_percent, count_num, in_grid
             area_less_threshold = 0
 
             if count_list[0] == 0:
-                area_less_threshold = sum(out_distribution[key] for key in count_list[1: smallest_max_count_ind + 1]) + \
-                                      count_zero_list[1]
+                area_less_threshold = sum(out_distribution[key] for key in count_list[1: smallest_max_count_ind + 1]) + count_zero_list[1]
+                
             else:
                 area_less_threshold = sum(out_distribution[key] for key in count_list[: smallest_max_count_ind + 1])
 
-            # print(area_less_threshold)
             if (float(area_less_threshold / total_area)) >= grid_percent:
                 stop_flag = True
 

--- a/tests/mqm/test_mqm_tool.py
+++ b/tests/mqm/test_mqm_tool.py
@@ -59,3 +59,4 @@ def test_stop_condition():
     count_list_6 = [2.0, 3.0, 4.0, 5.0, 7.0, 8.0, 9.0, 10.0, 11.0, 16.0, 18.0, 20.0, 21.0, 31.0]
     test_case_6 = mqm.stop_condition(count_zero_list_6, count_list_6, 0.9, 5, 15, out_distribution_6)
     assert test_case_6 == True
+    

--- a/tests/mqm/test_mqm_tool.py
+++ b/tests/mqm/test_mqm_tool.py
@@ -1,17 +1,14 @@
 import mqm
 import pytest
-import OS
+import os
 
 
 def test_import():
     assert mqm.road_count is not None
 
-def test_stop_condition():
-    """ Test Stop Condition
-
-    Verify if the stop condition is accurate and correct
-
-       Args:
+""" Stop Condition Testing 
+ 
+ Args:
         count_zero_list: a pair to the number of grids with zero flagged feature.
         count_list: a list to the number of flagged features.
         grid_percent: a percentage value for grids.
@@ -20,20 +17,25 @@ def test_stop_condition():
         out_distribution: a dictionary in which key and value represent the number of flagged features and counts, respectively.
 
     Returns: stop_flag =True or False
+"""
 
-    """
+
+def test_default_stop_condition():
     out_distribution_1 = {3.0: 2, 10.0: 1, 65.0: 1, 77.0: 1, 102.0: 1}
     count_zero_list_1 = [0, 2]
     count_list_1 = [13.0, 65.0, 179.0]
-    test_case_1 = mqm.stop_condition(count_zero_list_1,count_list_1,0.9,10,5,out_distribution_1)
+    test_case_1 = mqm.stop_condition(count_zero_list_1, count_list_1, 0.9, 10, 5, out_distribution_1)
     assert test_case_1 == False
 
-    out_distribution_2 = {2.0: 4, 3.0: 3, 4.0: 7, 5.0: 1, 6.0: 1, 8.0: 1, 9.0: 2, 10.0: 2, 11.0: 1, 13.0: 1, 18.0: 1, 19.0: 1, 20.0: 1, 23.0: 1, 31.0: 2}
+    out_distribution_2 = {2.0: 4, 3.0: 3, 4.0: 7, 5.0: 1, 6.0: 1, 8.0: 1, 9.0: 2, 10.0: 2, 11.0: 1, 13.0: 1, 18.0: 1,
+                          19.0: 1, 20.0: 1, 23.0: 1, 31.0: 2}
     count_zero_list_2 = [0, 99]
     count_list_2 = [2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 9.0, 10.0, 11.0, 13.0, 18.0, 19.0, 20.0, 23.0, 31.0]
     test_case_2 = mqm.stop_condition(count_zero_list_2, count_list_2, 0.9, 10, 15, out_distribution_2)
     assert test_case_2 == True
 
+
+def test_percentage_stop_condition():
     out_distribution_3 = {2.0: 4, 3.0: 3, 4.0: 7, 5.0: 1, 6.0: 1, 8.0: 1, 9.0: 2, 10.0: 2, 11.0: 1, 13.0: 1, 18.0: 1,
                           19.0: 1, 20.0: 1, 23.0: 1, 31.0: 2}
     count_zero_list_3 = [0, 99]
@@ -41,12 +43,15 @@ def test_stop_condition():
     test_case_3 = mqm.stop_condition(count_zero_list_3, count_list_3, 0.95, 10, 15, out_distribution_3)
     assert test_case_3 == False
 
-    out_distribution_4 = {2.0: 7, 3.0: 7, 4.0: 8, 5.0: 2, 7.0: 2, 8.0: 2, 9.0: 1, 10.0: 1, 11.0: 1, 16.0: 1, 18.0: 1, 20.0: 1, 21.0: 1, 31.0: 2}
+    out_distribution_4 = {2.0: 7, 3.0: 7, 4.0: 8, 5.0: 2, 7.0: 2, 8.0: 2, 9.0: 1, 10.0: 1, 11.0: 1, 16.0: 1, 18.0: 1,
+                          20.0: 1, 21.0: 1, 31.0: 2}
     count_zero_list_4 = [0, 219]
     count_list_4 = [2.0, 3.0, 4.0, 5.0, 7.0, 8.0, 9.0, 10.0, 11.0, 16.0, 18.0, 20.0, 21.0, 31.0]
     test_case_4 = mqm.stop_condition(count_zero_list_4, count_list_4, 0.95, 10, 15, out_distribution_4)
     assert test_case_4 == True
 
+
+def test_min_counts_stop_condition():
     out_distribution_5 = {2.0: 4, 3.0: 3, 4.0: 7, 5.0: 1, 6.0: 1, 8.0: 1, 9.0: 2, 10.0: 2, 11.0: 1, 13.0: 1, 18.0: 1,
                           19.0: 1, 20.0: 1, 23.0: 1, 31.0: 2}
     count_zero_list_5 = [0, 99]
@@ -54,9 +59,9 @@ def test_stop_condition():
     test_case_5 = mqm.stop_condition(count_zero_list_5, count_list_5, 0.9, 5, 15, out_distribution_5)
     assert test_case_5 == False
 
-    out_distribution_6 = {2.0: 7, 3.0: 7, 4.0: 8, 5.0: 2, 7.0: 2, 8.0: 2, 9.0: 1, 10.0: 1, 11.0: 1, 16.0: 1, 18.0: 1, 20.0: 1, 21.0: 1, 31.0: 2}
+    out_distribution_6 = {2.0: 7, 3.0: 7, 4.0: 8, 5.0: 2, 7.0: 2, 8.0: 2, 9.0: 1, 10.0: 1, 11.0: 1, 16.0: 1, 18.0: 1,
+                          20.0: 1, 21.0: 1, 31.0: 2}
     count_zero_list_6 = [0, 219]
     count_list_6 = [2.0, 3.0, 4.0, 5.0, 7.0, 8.0, 9.0, 10.0, 11.0, 16.0, 18.0, 20.0, 21.0, 31.0]
     test_case_6 = mqm.stop_condition(count_zero_list_6, count_list_6, 0.9, 5, 15, out_distribution_6)
     assert test_case_6 == True
-    

--- a/tests/mqm/test_mqm_tool.py
+++ b/tests/mqm/test_mqm_tool.py
@@ -1,5 +1,61 @@
 import mqm
+import pytest
+import OS
 
 
 def test_import():
     assert mqm.road_count is not None
+
+def test_stop_condition():
+    """ Test Stop Condition
+
+    Verify if the stop condition is accurate and correct
+
+       Args:
+        count_zero_list: a pair to the number of grids with zero flagged feature.
+        count_list: a list to the number of flagged features.
+        grid_percent: a percentage value for grids.
+        count_num: a count number for a stop condition in the first k-d tree.
+        cell_num: the number of keys in the dictionary.
+        out_distribution: a dictionary in which key and value represent the number of flagged features and counts, respectively.
+
+    Returns: stop_flag =True or False
+
+    """
+    out_distribution_1 = {3.0: 2, 10.0: 1, 65.0: 1, 77.0: 1, 102.0: 1}
+    count_zero_list_1 = [0, 2]
+    count_list_1 = [13.0, 65.0, 179.0]
+    test_case_1 = mqm.stop_condition(count_zero_list_1,count_list_1,0.9,10,5,out_distribution_1)
+    assert test_case_1 == False
+
+    out_distribution_2 = {2.0: 4, 3.0: 3, 4.0: 7, 5.0: 1, 6.0: 1, 8.0: 1, 9.0: 2, 10.0: 2, 11.0: 1, 13.0: 1, 18.0: 1, 19.0: 1, 20.0: 1, 23.0: 1, 31.0: 2}
+    count_zero_list_2 = [0, 99]
+    count_list_2 = [2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 9.0, 10.0, 11.0, 13.0, 18.0, 19.0, 20.0, 23.0, 31.0]
+    test_case_2 = mqm.stop_condition(count_zero_list_2, count_list_2, 0.9, 10, 15, out_distribution_2)
+    assert test_case_2 == True
+
+    out_distribution_3 = {2.0: 4, 3.0: 3, 4.0: 7, 5.0: 1, 6.0: 1, 8.0: 1, 9.0: 2, 10.0: 2, 11.0: 1, 13.0: 1, 18.0: 1,
+                          19.0: 1, 20.0: 1, 23.0: 1, 31.0: 2}
+    count_zero_list_3 = [0, 99]
+    count_list_3 = [2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 9.0, 10.0, 11.0, 13.0, 18.0, 19.0, 20.0, 23.0, 31.0]
+    test_case_3 = mqm.stop_condition(count_zero_list_3, count_list_3, 0.95, 10, 15, out_distribution_3)
+    assert test_case_3 == False
+
+    out_distribution_4 = {2.0: 7, 3.0: 7, 4.0: 8, 5.0: 2, 7.0: 2, 8.0: 2, 9.0: 1, 10.0: 1, 11.0: 1, 16.0: 1, 18.0: 1, 20.0: 1, 21.0: 1, 31.0: 2}
+    count_zero_list_4 = [0, 219]
+    count_list_4 = [2.0, 3.0, 4.0, 5.0, 7.0, 8.0, 9.0, 10.0, 11.0, 16.0, 18.0, 20.0, 21.0, 31.0]
+    test_case_4 = mqm.stop_condition(count_zero_list_4, count_list_4, 0.95, 10, 15, out_distribution_4)
+    assert test_case_4 == True
+
+    out_distribution_5 = {2.0: 4, 3.0: 3, 4.0: 7, 5.0: 1, 6.0: 1, 8.0: 1, 9.0: 2, 10.0: 2, 11.0: 1, 13.0: 1, 18.0: 1,
+                          19.0: 1, 20.0: 1, 23.0: 1, 31.0: 2}
+    count_zero_list_5 = [0, 99]
+    count_list_5 = [2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 9.0, 10.0, 11.0, 13.0, 18.0, 19.0, 20.0, 23.0, 31.0]
+    test_case_5 = mqm.stop_condition(count_zero_list_5, count_list_5, 0.9, 5, 15, out_distribution_5)
+    assert test_case_5 == False
+
+    out_distribution_6 = {2.0: 7, 3.0: 7, 4.0: 8, 5.0: 2, 7.0: 2, 8.0: 2, 9.0: 1, 10.0: 1, 11.0: 1, 16.0: 1, 18.0: 1, 20.0: 1, 21.0: 1, 31.0: 2}
+    count_zero_list_6 = [0, 219]
+    count_list_6 = [2.0, 3.0, 4.0, 5.0, 7.0, 8.0, 9.0, 10.0, 11.0, 16.0, 18.0, 20.0, 21.0, 31.0]
+    test_case_6 = mqm.stop_condition(count_zero_list_6, count_list_6, 0.9, 5, 15, out_distribution_6)
+    assert test_case_6 == True


### PR DESCRIPTION
**Summary:** This PR is addressing the grid stop condition to be accurate. Changes involve how to count total grids as well as the grid counts less than "cold spot definition, default <10 failures in any given grid". Add the unit tests

**Addressing issue** https://github.com/spatialdev/osmquality/issues/20 

**Test results**: 
1) In default, new changes make sure the counts over 10 is less than 10% of the total grid counts (25/256)
![Screen Shot 2019-10-14 at 1 21 33 PM](https://user-images.githubusercontent.com/36048303/66780664-414b6800-ee86-11e9-84c7-0179dc8514ee.png)

2) with customizing arugment (95% of grids contain less than 5 map error per grid) -> our results showed that grid counts >5 are 42/1024 (<5%) 
![Screen Shot 2019-10-14 at 1 46 24 PM](https://user-images.githubusercontent.com/36048303/66782246-1d8a2100-ee8a-11e9-9c39-2641545688b6.png)
